### PR TITLE
test(cli): test success/failure case

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,12 @@
   "dependencies": {
     "node-getopt": "^0.2.3",
     "retry": "^0.9.0"
+  },
+  "devDependencies": {
+    "ava": "^0.12.0",
+    "execa": "^0.2.2"
+  },
+  "scripts": {
+    "test": "ava"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,20 @@
+const test = require('ava');
+const execa = require('execa');
+
+test('success case', t => {
+  return execa('node', ['./cli.js', '--', 'echo', 'asdf']).then((result) => {
+    t.ok(result.stdout === 'asdf');
+    t.ok(result.stderr === '');
+  });
+});
+test('retry case', t => {
+  return execa('node', ['./cli.js', '-n', '3', '-t', '100', '--', 'ls', 'asdf']).then((result) => {
+    const err =
+`ls: asdf: No such file or directory
+ls: asdf: No such file or directory
+ls: asdf: No such file or directory
+ls: asdf: No such file or directory`;
+    t.ok(result.stdout === '');
+    t.ok(result.stderr === err);
+  });
+});


### PR DESCRIPTION
This is a draft proposal :cactus: 
I added tests for success/failure case. What do you think?

Which test runner do you like ava or mocha?
Which CI-service do you like travis-ci, circle-ci or wercker?

:smile_cat: 

You can run test:
```
$ npm run test

> retry-cli@0.3.0 test /Users/sane/work/js-study/retry-cli
> ava


  2 passed
```